### PR TITLE
CORS周りの処理のリファクタリング

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -587,15 +587,6 @@
         "hono": "^4"
       }
     },
-    "node_modules/@hono/zod-validator": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@hono/zod-validator/-/zod-validator-0.3.0.tgz",
-      "integrity": "sha512-7XcTk3yYyk6ldrO/VuqsroE7stvDZxHJQcpATRAyha8rUxJNBPV3+6waDrARfgEqxOVlzIadm3/6sE/dPseXgQ==",
-      "peerDependencies": {
-        "hono": ">=3.9.0",
-        "zod": "^3.19.1"
-      }
-    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -2059,7 +2050,7 @@
       "version": "5.5.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
       "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2115,6 +2106,20 @@
       ],
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/valibot": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-0.42.1.tgz",
+      "integrity": "sha512-3keXV29Ar5b//Hqi4MbSdV7lfVp6zuYLZuA9V1PvQUsXqogr+u5lvLPLk3A4f74VUXDnf/JfWMN6sB+koJ/FFw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/which": {
@@ -2627,6 +2632,7 @@
       "version": "3.23.8",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
       "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -2674,9 +2680,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@hono/zod-validator": "^0.3.0",
         "@skyway-sdk/token": "^1.6.2",
-        "zod": "^3.23.8"
+        "valibot": "^0.42.1"
       },
       "devDependencies": {
         "wrangler": "^3.57.2"
@@ -2969,12 +2974,6 @@
       "integrity": "sha512-xjzhqhSWUE/OhN0g3KCNVzNsQMlFUAL+/8GgPUr3TKcU7cvgZVBGswFofJ8WwGEHTqobzze1lDpGJl9ZNckDhA==",
       "requires": {}
     },
-    "@hono/zod-validator": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@hono/zod-validator/-/zod-validator-0.3.0.tgz",
-      "integrity": "sha512-7XcTk3yYyk6ldrO/VuqsroE7stvDZxHJQcpATRAyha8rUxJNBPV3+6waDrARfgEqxOVlzIadm3/6sE/dPseXgQ==",
-      "requires": {}
-    },
     "@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -3054,10 +3053,9 @@
     "@udonarium-backend/core": {
       "version": "file:packages/shared/core",
       "requires": {
-        "@hono/zod-validator": "^0.3.0",
         "@skyway-sdk/token": "^1.6.2",
-        "wrangler": "^3.57.2",
-        "zod": "^3.23.8"
+        "valibot": "^0.42.1",
+        "wrangler": "^3.57.2"
       }
     },
     "@udonarium-backend/nodejs": {
@@ -3966,7 +3964,7 @@
       "version": "5.5.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
       "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
-      "dev": true
+      "devOptional": true
     },
     "ufo": {
       "version": "1.5.4",
@@ -4005,6 +4003,12 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+    },
+    "valibot": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-0.42.1.tgz",
+      "integrity": "sha512-3keXV29Ar5b//Hqi4MbSdV7lfVp6zuYLZuA9V1PvQUsXqogr+u5lvLPLk3A4f74VUXDnf/JfWMN6sB+koJ/FFw==",
+      "requires": {}
     },
     "which": {
       "version": "2.0.2",
@@ -4268,7 +4272,8 @@
     "zod": {
       "version": "3.23.8",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g=="
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "dev": true
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "hono": "^4.5.9"
       },
       "devDependencies": {
-        "typescript": "^5.0.4"
+        "typescript": "^5.2.2"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -587,6 +587,15 @@
         "hono": "^4"
       }
     },
+    "node_modules/@hono/zod-validator": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@hono/zod-validator/-/zod-validator-0.3.0.tgz",
+      "integrity": "sha512-7XcTk3yYyk6ldrO/VuqsroE7stvDZxHJQcpATRAyha8rUxJNBPV3+6waDrARfgEqxOVlzIadm3/6sE/dPseXgQ==",
+      "peerDependencies": {
+        "hono": ">=3.9.0",
+        "zod": "^3.19.1"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -613,20 +622,20 @@
       }
     },
     "node_modules/@skyway-sdk/common": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/@skyway-sdk/common/-/common-1.4.7.tgz",
-      "integrity": "sha512-RQ5uy+4bGwmw/fzy/ZkOsrhZhjsAatdN3XthBuHSgl6y/xq78PUwnpi9FGT29Q3DdJytCLZ4xG0vV2O4aRybwQ==",
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@skyway-sdk/common/-/common-1.4.8.tgz",
+      "integrity": "sha512-+Qa4yYO5jbzZbM1W2crQcq+UrmjD5yyfHyLvUjEQIdGYTxD7Iej0fX47mo54mNec3QMOj6UYKPraTyVp36hGUw==",
       "dependencies": {
-        "axios": "^1.6.0"
+        "axios": "^1.7.7"
       }
     },
     "node_modules/@skyway-sdk/token": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@skyway-sdk/token/-/token-1.6.1.tgz",
-      "integrity": "sha512-SFqNpSdbnmEYwgrGi9XXgBUCgRpGpgVtUllrjFzJY5xG0MWH6ZkVaxCTq+u+xFi2e2uzVUtP0D1N0lfYxVZHSg==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@skyway-sdk/token/-/token-1.6.3.tgz",
+      "integrity": "sha512-g0zHs+P8fvN9U9TV4LVmwlQDt0q0hXEevRip1q3k8QT+bwXrUjyLnXUpj+2wMPhLl3t1fXIRahvq32paPApmCg==",
       "dependencies": {
-        "@skyway-sdk/common": "^1.4.7",
-        "jsrsasign": "^11.0.0",
+        "@skyway-sdk/common": "^1.4.8",
+        "jsrsasign": "^11.1.0",
         "jwt-decode": "3.1.2",
         "uuid": "^9.0.0"
       }
@@ -2618,7 +2627,6 @@
       "version": "3.23.8",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
       "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -2666,7 +2674,9 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@skyway-sdk/token": "^1.4.5"
+        "@hono/zod-validator": "^0.3.0",
+        "@skyway-sdk/token": "^1.6.2",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "wrangler": "^3.57.2"
@@ -2959,6 +2969,12 @@
       "integrity": "sha512-xjzhqhSWUE/OhN0g3KCNVzNsQMlFUAL+/8GgPUr3TKcU7cvgZVBGswFofJ8WwGEHTqobzze1lDpGJl9ZNckDhA==",
       "requires": {}
     },
+    "@hono/zod-validator": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@hono/zod-validator/-/zod-validator-0.3.0.tgz",
+      "integrity": "sha512-7XcTk3yYyk6ldrO/VuqsroE7stvDZxHJQcpATRAyha8rUxJNBPV3+6waDrARfgEqxOVlzIadm3/6sE/dPseXgQ==",
+      "requires": {}
+    },
     "@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -2982,20 +2998,20 @@
       }
     },
     "@skyway-sdk/common": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/@skyway-sdk/common/-/common-1.4.7.tgz",
-      "integrity": "sha512-RQ5uy+4bGwmw/fzy/ZkOsrhZhjsAatdN3XthBuHSgl6y/xq78PUwnpi9FGT29Q3DdJytCLZ4xG0vV2O4aRybwQ==",
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@skyway-sdk/common/-/common-1.4.8.tgz",
+      "integrity": "sha512-+Qa4yYO5jbzZbM1W2crQcq+UrmjD5yyfHyLvUjEQIdGYTxD7Iej0fX47mo54mNec3QMOj6UYKPraTyVp36hGUw==",
       "requires": {
-        "axios": "^1.6.0"
+        "axios": "^1.7.7"
       }
     },
     "@skyway-sdk/token": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@skyway-sdk/token/-/token-1.6.1.tgz",
-      "integrity": "sha512-SFqNpSdbnmEYwgrGi9XXgBUCgRpGpgVtUllrjFzJY5xG0MWH6ZkVaxCTq+u+xFi2e2uzVUtP0D1N0lfYxVZHSg==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@skyway-sdk/token/-/token-1.6.3.tgz",
+      "integrity": "sha512-g0zHs+P8fvN9U9TV4LVmwlQDt0q0hXEevRip1q3k8QT+bwXrUjyLnXUpj+2wMPhLl3t1fXIRahvq32paPApmCg==",
       "requires": {
-        "@skyway-sdk/common": "^1.4.7",
-        "jsrsasign": "^11.0.0",
+        "@skyway-sdk/common": "^1.4.8",
+        "jsrsasign": "^11.1.0",
         "jwt-decode": "3.1.2",
         "uuid": "^9.0.0"
       }
@@ -3038,8 +3054,10 @@
     "@udonarium-backend/core": {
       "version": "file:packages/shared/core",
       "requires": {
-        "@skyway-sdk/token": "^1.4.5",
-        "wrangler": "^3.57.2"
+        "@hono/zod-validator": "^0.3.0",
+        "@skyway-sdk/token": "^1.6.2",
+        "wrangler": "^3.57.2",
+        "zod": "^3.23.8"
       }
     },
     "@udonarium-backend/nodejs": {
@@ -4250,8 +4268,7 @@
     "zod": {
       "version": "3.23.8",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
-      "dev": true
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g=="
     }
   }
 }

--- a/packages/shared/core/package.json
+++ b/packages/shared/core/package.json
@@ -8,9 +8,8 @@
     "compile": "tsc"
   },
   "dependencies": {
-    "@hono/zod-validator": "^0.3.0",
     "@skyway-sdk/token": "^1.6.2",
-    "zod": "^3.23.8"
+    "valibot": "^0.42.1"
   },
   "devDependencies": {
     "wrangler": "^3.57.2"

--- a/packages/shared/core/package.json
+++ b/packages/shared/core/package.json
@@ -8,7 +8,9 @@
     "compile": "tsc"
   },
   "dependencies": {
-    "@skyway-sdk/token": "^1.6.2"
+    "@hono/zod-validator": "^0.3.0",
+    "@skyway-sdk/token": "^1.6.2",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "wrangler": "^3.57.2"


### PR DESCRIPTION
## 概要

`@udonarium-backend/core` のリファクタリング
preflight有り・無しを含めた厳密な処理ができるようになります。

### 詳細

1. 独自ミドルウェアで行っていた処理をビルドインの[CORSミドルウェア](https://hono.dev/docs/middleware/builtin/cors)で処理するように変更
2. 複数のContent-TypeのBodyを処理できるように変更 (`application/json`, `application/x-www-form-urlencoded`, `text/plain`)
3. バリデーションを軽量の[valibot](https://valibot.dev/)で処理できるように変更
4. 3に伴って不必要になったインターフェースを削除

### バンドルサイズの増加

| file name | main branch build size |  this branch build size |
|-|-|-|
|`dist/aws-lambda/index.js`| 26.5 KiB | 31.4 KiB(+4.9 KiB) |
|`dist/cloudflare-workers/index.js`|  22.3 KiB  | 26.8 KiB(+4.5 KiB) |
|`dist/nodejs/index.js`| 28.8 KiB | 33.6 KiB(+4.8 KiB) |
